### PR TITLE
Fix building with maven (spock-core version), fix crash with zero-dimension windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.spockframework</groupId>
 			<artifactId>spock-core</artifactId>
-			<version>1.0-groovy-2.0-SNAPSHOT</version>
+			<version>1.0-groovy-2.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/zag-swing/src/main/java/org/p2c2e/zing/swing/GraphicsWindow.java
+++ b/zag-swing/src/main/java/org/p2c2e/zing/swing/GraphicsWindow.java
@@ -76,6 +76,14 @@ public class GraphicsWindow extends Window implements IGraphicsWindow {
 
 	@Override
 	public synchronized void rearrange(Rectangle r) {
+
+		// Some games use zero-height or zero-width windows which crash the terp.
+		if(r.height <= 0) {
+			r.height=1;
+		}
+		if(r.width <= 0) {
+			r.width=1;
+		}
 		BufferedImage nbi = graphConfig.createCompatibleImage(r.width,
 				r.height, Transparency.TRANSLUCENT);
 		Graphics2D ng2d = nbi.createGraphics();

--- a/zag-swing/src/main/java/org/p2c2e/zing/swing/GraphicsWindow.java
+++ b/zag-swing/src/main/java/org/p2c2e/zing/swing/GraphicsWindow.java
@@ -77,12 +77,9 @@ public class GraphicsWindow extends Window implements IGraphicsWindow {
 	@Override
 	public synchronized void rearrange(Rectangle r) {
 
-		// Some games use zero-height or zero-width windows which crash the terp.
-		if(r.height <= 0) {
-			r.height=1;
-		}
-		if(r.width <= 0) {
-			r.width=1;
+		// Some games use zero-height or zero-width windows which crash the terp if not caught
+		if(r.height <= 0 || r.width <= 0) {
+			return;
 		}
 		BufferedImage nbi = graphConfig.createCompatibleImage(r.width,
 				r.height, Transparency.TRANSLUCENT);


### PR DESCRIPTION
I fixed pom.xml for spock-core, since "1.0-groovy-2.0" is no longer a snapshot but a proper release, and also fixed an issue I encountered in a game where a window had zero height that caused an exception. My fix is kind of awful, in that it says "if a height or width is zero, set that height or width to 1 instead."

But it made the game playable, FWIW.